### PR TITLE
ftime: New frame time device

### DIFF
--- a/aquabsd.alps.ftime/build.sh
+++ b/aquabsd.alps.ftime/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cc "$@" -shared -fPIC

--- a/aquabsd.alps.ftime/functions.h
+++ b/aquabsd.alps.ftime/functions.h
@@ -22,8 +22,9 @@ ftime_t* create(double target) {
 	return ftime;
 }
 
-void draw(ftime_t* ftime) {
+double draw(ftime_t* ftime) {
 	ftime->draw_start = __get_time();
+	return ftime->total_time;
 }
 
 // swapping happens at the end of the draw
@@ -97,13 +98,13 @@ void done(ftime_t* ftime) {
 	#define DIVERGENCE_TOLERANCE (1 + 0.40)
 
 	double swap_time = __get_time() - ftime->swap_start;
-	double total_time = swap_time + ftime->draw_time + ftime->wait_time;
+	ftime->total_time = swap_time + ftime->draw_time + ftime->wait_time;
 
 	if (
-		total_time > ftime->target * DIVERGENCE_TOLERANCE ||
-		total_time < ftime->target / DIVERGENCE_TOLERANCE
+		ftime->total_time > ftime->target * DIVERGENCE_TOLERANCE ||
+		ftime->total_time < ftime->target / DIVERGENCE_TOLERANCE
 	) {
-		LOG_WARN("Total frame time (draw + swap + wait time = %g) is not within %g%% of the target (%g); this means the target passed is likely incorrect", total_time, (DIVERGENCE_TOLERANCE - 1) * 100, ftime->target)
+		LOG_WARN("Total frame time (draw + swap + wait times = %g) is not within %g%% of the target (%g); this means the target passed is likely incorrect", ftime->total_time, (DIVERGENCE_TOLERANCE - 1) * 100, ftime->target)
 	}
 
 	// compute 1% lows (in terms of FPS, so 99th percentile in frametimes)
@@ -130,8 +131,9 @@ void done(ftime_t* ftime) {
 	}
 
 	#define CONSERVANCY 1.2
+	ftime->wait_time /= CONSERVANCY;
 
-	useconds_t us = ftime->wait_time / CONSERVANCY * 1000000;
+	useconds_t us = ftime->wait_time * 1000000;
 	usleep(us);
 }
 

--- a/aquabsd.alps.ftime/functions.h
+++ b/aquabsd.alps.ftime/functions.h
@@ -1,0 +1,103 @@
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+
+static inline double __get_time(void) {
+	struct timespec timer;
+	clock_gettime(CLOCK_MONOTONIC, &timer);
+
+	return timer.tv_sec + 1.e-9 * timer.tv_nsec;
+}
+
+ftime_t* create(double target) {
+	ftime_t* ftime = calloc(1, sizeof *ftime);
+
+	ftime->target = target;
+	ftime->times = malloc(RECORDED_FTIMES * sizeof *ftime->times);
+
+	return ftime;
+}
+
+void draw(ftime_t* ftime) {
+	// compute 1% lows (in terms of FPS, so 99th percentile in frametimes)
+	// that is, what frametime has 99% of other frametimes below it?
+	// if we don't yet have any data for this, don't wait at all before drawing
+
+	ftime->expected_draw_time = 0;
+	size_t len = RECORDED_FTIMES / 100;
+
+	for (size_t i = 0; i < MIN(ftime->times_count, len); i++) {
+		ftime->expected_draw_time += ftime->times[i];
+	}
+
+	// add epsilon so division is defined when 'ftime->times_count == 0'
+
+	ftime->expected_draw_time /= ftime->times_count + 0.000001;
+
+	// wait for 'ftime->target' subtracted by the time we expect the draw to take
+	// if that time ends up being less than zero, don't wait at all in an attempt to recover performance
+
+	double wait_time = ftime->target - ftime->expected_draw_time;
+
+	if (wait_time < 0) {
+		wait_time = 0;
+		LOG_WARN("Expecting draw time (%g) to take longer than target (%g); this means things are running slower than they should!")
+	}
+
+	int us = wait_time * 1000000;
+	usleep(us);
+
+	// we can now start drawing
+
+	ftime->draw_start = __get_time();
+}
+
+// swapping happens at the end of the draw
+
+void swap(ftime_t* ftime) {
+	// insert time taken to draw to the list of recorded frametimes
+	// this may look like O(n^2), but it's actually O(n)
+
+	double draw_end = __get_time();
+	double draw_time = draw_end - ftime->draw_start;
+
+	for (size_t i = 0; i < ftime->times_count; i++) {
+		double time = ftime->times[i];
+
+		if (draw_time > time) {
+			continue;
+		}
+
+		// move everything >= i to the right
+		// if at the end of the list, forget about it, it's anyway too small to be significant to us
+
+		for (size_t j = ftime->times_count - 1; j >= i; j--) {
+			ftime->times[j + 1] = ftime->times[j];
+		}
+
+		ftime->times[i] = draw_time;
+		goto added_time;
+	}
+
+	// draw time is smaller than anything in the list, so add it to the end
+	// if list is already full, forget about it, it's anyway too small to be significant to us
+
+	if (ftime->times_count < RECORDED_FTIMES) {
+		ftime->times[ftime->times_count++] = draw_time;
+	}
+
+added_time:
+
+	ftime->swap_start = draw_end;
+}
+
+void done(ftime_t* ftime) {
+	// double swap_end = __get_time();
+}
+
+void delete(ftime_t* ftime) {
+	free(ftime->times);
+	free(ftime);
+}

--- a/aquabsd.alps.ftime/functions.h
+++ b/aquabsd.alps.ftime/functions.h
@@ -33,7 +33,7 @@ void swap(ftime_t* ftime) {
 	double draw_end = __get_time();
 	double draw_time = draw_end - ftime->draw_start;
 
-	for (size_t i = 0; i < ftime->times_count; i++) {
+	for (ssize_t i = 0; i < ftime->times_count; i++) {
 		double time = ftime->times[i];
 
 		if (draw_time > time) {
@@ -43,7 +43,7 @@ void swap(ftime_t* ftime) {
 		// move everything >= i to the right
 		// if at the end of the list, forget about it, it's anyway too small to be significant to us
 
-		for (size_t j = ftime->times_count - 1; j >= i; j--) {
+		for (ssize_t j = ftime->times_count - 1; j >= i; j--) {
 			ftime->times[j + 1] = ftime->times[j];
 		}
 

--- a/aquabsd.alps.ftime/main.c
+++ b/aquabsd.alps.ftime/main.c
@@ -1,12 +1,18 @@
 #include <aquabsd.alps.ftime/private.h>
+#include <aquabsd.alps.ftime/functions.h>
 
 typedef enum {
-	TODO
+	CMD_CREATE = 0x6674, // 'ft'
 } cmd_t;
 
 uint64_t send(uint16_t _cmd, void* data) {
-	__attribute__((unused)) cmd_t cmd = _cmd;
-	__attribute__((unused)) uint64_t* args = data;
+	cmd_t cmd = _cmd;
+	uint64_t* args = data;
+
+	if (cmd == CMD_CREATE) {
+		double target = *(double*) &args[0];
+		return (uint64_t) create(target);
+	}
 
 	return -1;
 }

--- a/aquabsd.alps.ftime/main.c
+++ b/aquabsd.alps.ftime/main.c
@@ -2,17 +2,14 @@
 #include <aquabsd.alps.ftime/functions.h>
 
 typedef enum {
-	CMD_CREATE = 0x6674, // 'ft'
+	TODO
 } cmd_t;
 
 uint64_t send(uint16_t _cmd, void* data) {
 	cmd_t cmd = _cmd;
 	uint64_t* args = data;
 
-	if (cmd == CMD_CREATE) {
-		double target = *(double*) &args[0];
-		return (uint64_t) create(target);
-	}
+	LOG_ERROR("This device is currently for exclusive use of other devices")
 
 	return -1;
 }

--- a/aquabsd.alps.ftime/main.c
+++ b/aquabsd.alps.ftime/main.c
@@ -6,8 +6,8 @@ typedef enum {
 } cmd_t;
 
 uint64_t send(uint16_t _cmd, void* data) {
-	cmd_t cmd = _cmd;
-	uint64_t* args = data;
+	__attribute__((unused)) cmd_t cmd = _cmd;
+	__attribute__((unused)) uint64_t* args = data;
 
 	LOG_ERROR("This device is currently for exclusive use of other devices")
 

--- a/aquabsd.alps.ftime/main.c
+++ b/aquabsd.alps.ftime/main.c
@@ -1,0 +1,12 @@
+#include <aquabsd.alps.ftime/private.h>
+
+typedef enum {
+	TODO
+} cmd_t;
+
+uint64_t send(uint16_t _cmd, void* data) {
+	__attribute__((unused)) cmd_t cmd = _cmd;
+	__attribute__((unused)) uint64_t* args = data;
+
+	return -1;
+}

--- a/aquabsd.alps.ftime/private.h
+++ b/aquabsd.alps.ftime/private.h
@@ -1,3 +1,8 @@
-#define dynamic
-
 #include <aquabsd.alps.ftime/public.h>
+
+#include <umber.h>
+#define UMBER_COMPONENT "aquabsd.alps.ftime"
+
+#define ftime_t aquabsd_alps_ftime_t
+
+#define RECORDED_FTIMES AQUABSD_ALPS_FTIME_RECORDED_FTIMES

--- a/aquabsd.alps.ftime/private.h
+++ b/aquabsd.alps.ftime/private.h
@@ -1,0 +1,3 @@
+#define dynamic
+
+#include <aquabsd.alps.ftime/public.h>

--- a/aquabsd.alps.ftime/private.h
+++ b/aquabsd.alps.ftime/private.h
@@ -3,6 +3,7 @@
 #include <umber.h>
 #define UMBER_COMPONENT "aquabsd.alps.ftime"
 
-#define ftime_t aquabsd_alps_ftime_t
+#define record_t aquabsd_alps_ftime_record_t
+#define ftime_t  aquabsd_alps_ftime_t
 
 #define RECORDED_FTIMES AQUABSD_ALPS_FTIME_RECORDED_FTIMES

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -1,0 +1,1 @@
+#include <stdint.h>

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -13,6 +13,9 @@ typedef struct {
 	double expected_draw_time; // how long do we expect the next draw to take?
 	double draw_start; // when did the last draw start?
 	double swap_start; // when did the last swap start? (same thing as when the draw ended)
+
+	double draw_time; // how long did the draw take?
+	double wait_time; // how long did we decide to wait last time?
 } aquabsd_alps_ftime_t;
 
 // how many frames do we take into account?

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -21,6 +21,7 @@ typedef struct {
 
 	double draw_time; // how long did the draw take?
 	double wait_time; // how long did we decide to wait last time?
+	double total_time; // how long was the total frame time (draw + swap + wait times)?
 } aquabsd_alps_ftime_t;
 
 // how many frames do we take into account?
@@ -30,7 +31,7 @@ typedef struct {
 #endif
 
 aquabsd_alps_ftime_t* (*aquabsd_alps_ftime_create) (double target);
-void (*aquabsd_alps_ftime_draw) (aquabsd_alps_ftime_t* ftime);
+double (*aquabsd_alps_ftime_draw) (aquabsd_alps_ftime_t* ftime);
 void (*aquabsd_alps_ftime_swap) (aquabsd_alps_ftime_t* ftime);
 void (*aquabsd_alps_ftime_done) (aquabsd_alps_ftime_t* ftime);
 void (*aquabsd_alps_ftime_delete) (aquabsd_alps_ftime_t* ftime);

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -5,10 +5,15 @@
 #include <stddef.h>
 
 typedef struct {
+	double frametime; // frametime itself
+	double when; // when was the frametime recorded? this is necessary to flush out outdated frametimes
+} aquabsd_alps_ftime_record_t;
+
+typedef struct {
 	double target; // what frametimes are we targetting? (1/60 for 60 Hz, 1/144 for 144 Hz, &c)
 
-	size_t times_count; // how many frametimes have we recorded so far?
-	double* times; // sorted (largest to smallest) list of recorded frametimes
+	size_t record_count; // how many frametimes have we recorded so far?
+	aquabsd_alps_ftime_record_t* records; // sorted (largest to smallest) list of recorded frametimes
 
 	double expected_draw_time; // how long do we expect the next draw to take?
 	double draw_start; // when did the last draw start?

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -1,1 +1,30 @@
+#if !defined(__AQUABSD_ALPS_FTIME)
+#define __AQUABSD_ALPS_FTIME
+
 #include <stdint.h>
+#include <stddef.h>
+
+typedef struct {
+	double target; // what frametimes are we targetting? (1/60 for 60 Hz, 1/144 for 144 Hz, &c)
+
+	size_t times_count; // how many frametimes have we recorded so far?
+	double* times; // sorted (largest to smallest) list of recorded frametimes
+
+	double expected_draw_time; // how long do we expect the next draw to take?
+	double draw_start; // when did the last draw start?
+	double swap_start; // when did the last swap start? (same thing as when the draw ended)
+} aquabsd_alps_ftime_t;
+
+// how many frames do we take into account?
+
+#if !defined(AQUABSD_ALPS_FTIME_RECORDED_FTIMES)
+	#define AQUABSD_ALPS_FTIME_RECORDED_FTIMES 1000
+#endif
+
+aquabsd_alps_ftime_t* (*aquabsd_alps_ftime_create) (double target);
+void (*aquabsd_alps_ftime_draw) (aquabsd_alps_ftime_t* ftime);
+void (*aquabsd_alps_ftime_swap) (aquabsd_alps_ftime_t* ftime);
+void (*aquabsd_alps_ftime_done) (aquabsd_alps_ftime_t* ftime);
+void (*aquabsd_alps_ftime_delete) (aquabsd_alps_ftime_t* ftime);
+
+#endif

--- a/aquabsd.alps.ftime/public.h
+++ b/aquabsd.alps.ftime/public.h
@@ -27,7 +27,7 @@ typedef struct {
 // how many frames do we take into account?
 
 #if !defined(AQUABSD_ALPS_FTIME_RECORDED_FTIMES)
-	#define AQUABSD_ALPS_FTIME_RECORDED_FTIMES 1000
+	#define AQUABSD_ALPS_FTIME_RECORDED_FTIMES 500
 #endif
 
 aquabsd_alps_ftime_t* (*aquabsd_alps_ftime_create) (double target);

--- a/aquabsd.alps.ogl/main.c
+++ b/aquabsd.alps.ogl/main.c
@@ -12,6 +12,20 @@ typedef enum {
 } cmd_t;
 
 int load(void) {
+	// aquabsd.alps.ftime
+
+	ftime_device = kos_query_device(0, (uint64_t) "aquabsd.alps.ftime");
+
+	if (ftime_device != -1) {
+		aquabsd_alps_ftime_create = kos_load_device_function(ftime_device, "create");
+		aquabsd_alps_ftime_draw   = kos_load_device_function(ftime_device, "draw"  );
+		aquabsd_alps_ftime_swap   = kos_load_device_function(ftime_device, "swap"  );
+		aquabsd_alps_ftime_done   = kos_load_device_function(ftime_device, "done"  );
+		aquabsd_alps_ftime_delete = kos_load_device_function(ftime_device, "delete");
+	}
+
+	// aquabsd.alps.win
+
     win_device = kos_query_device(0, (uint64_t) "aquabsd.alps.win");
 
 	if (win_device != -1) {

--- a/aquabsd.alps.ogl/main.c
+++ b/aquabsd.alps.ogl/main.c
@@ -32,12 +32,12 @@ int load(
 
 uint64_t send(uint16_t _cmd, void* data) {
 	cmd_t cmd = _cmd;
-	uint64_t* args = (uint64_t*) data;
+	uint64_t* args = data;
 
 	if (cmd == CMD_CREATE) {
 		context_type_t type = args[0];
 		context_t* context = NULL;
-		
+
 		if (type == CONTEXT_TYPE_WIN && win_device != -1) {
 			aquabsd_alps_win_t* win = (void*) args[1];
 			context = create_win_context(win);

--- a/aquabsd.alps.ogl/private.h
+++ b/aquabsd.alps.ogl/private.h
@@ -8,6 +8,7 @@ static void* (*kos_load_device_function) (uint64_t device, const char* name);
 static uint64_t (*kos_callback) (uint64_t callback, int argument_count, ...);
 
 static uint64_t win_device = -1;
+static uint64_t ftime_device = -1;
 
 #define context_type_t aquabsd_alps_ogl_context_type_t
 

--- a/aquabsd.alps.ogl/public.h
+++ b/aquabsd.alps.ogl/public.h
@@ -24,6 +24,7 @@ typedef struct {
 
 	// frame timing stuff
 
+	double target_ftime;
 	aquabsd_alps_ftime_t* ftime;
 
 	// EGL stuff

--- a/aquabsd.alps.ogl/public.h
+++ b/aquabsd.alps.ogl/public.h
@@ -1,6 +1,7 @@
 #if !defined(__AQUABSD_ALPS_OGL)
 #define __AQUABSD_ALPS_OGL
 
+#include <aquabsd.alps.ftime/public.h>
 #include <aquabsd.alps.win/public.h>
 
 #include <EGL/egl.h>
@@ -20,6 +21,10 @@ typedef struct {
 
 	aquabsd_alps_win_t* win;
 	xcb_window_t draw_win;
+
+	// frame timing stuff
+
+	aquabsd_alps_ftime_t* ftime;
 
 	// EGL stuff
 


### PR DESCRIPTION
The idea behind this is to move the frame timing code out from the `aquabsd.alps.ogl` device to:

- Make it reusable by future similar devices (such as the rewrite of `aquabsd.alps.vga` for the `vt` display driver on aquaBSD core and also an MIT-SHM framebuffer backend for windows, similar to what currently exists as the X11 backend for `aquabsd.alps.vga`).
- Be able to implement more advanced frame time prediction in the future, either bringing in from special hardware information or, if I wanna get super fancy, by training a model (LSTM or so) to be able to predict future frametimes.