### PR TITLE
aquabsd.alps.font: Completely revamp API

### DIFF
--- a/aquabsd.alps/aquabsd.alps.font/functions.h
+++ b/aquabsd.alps/aquabsd.alps.font/functions.h
@@ -217,7 +217,14 @@ dynamic int text_i_to_pos(text_t* text, uint64_t i, uint64_t* x_ref, uint64_t* y
 
 	gen_layout(text);
 
-	/* TODO */
+	PangoRectangle rect;
+	pango_layout_index_to_pos(text->layout, i, &rect);
+
+	*x_ref = rect.x / PANGO_SCALE;
+	*y_ref = rect.y / PANGO_SCALE;
+
+	*width_ref  = rect.width  / PANGO_SCALE;
+	*height_ref = rect.height / PANGO_SCALE;
 
 	return -1;
 }

--- a/aquabsd.alps/aquabsd.alps.font/functions.h
+++ b/aquabsd.alps/aquabsd.alps.font/functions.h
@@ -215,11 +215,21 @@ dynamic int text_get_res(text_t* text, uint64_t* x_res_ref, uint64_t* y_res_ref)
 }
 
 dynamic int text_pos_to_i(text_t* text, uint64_t x, uint64_t y) {
+	x *= PANGO_SCALE;
+	y *= PANGO_SCALE;
+
 	gen_layout(text);
 
-	/* TODO */
+	int i, trailing;
+	pango_layout_xy_to_index(text->layout, x, y, &i, &trailing);
 
-	return -1;
+	// 'trailing' tells us where in the character we are
+	// e.g., if we clicked on an "m" in the first half, 'trailing' would be '0'
+	// conversely, if we clicked in the second half, 'trailing; would be '1'
+	// TODO for now, I'm just adding these together to shift the index if clicking on the second half of the character
+	//      however, it would be nice for the user to have access to this information in fine
+
+	return i + trailing;
 }
 
 dynamic int text_i_to_pos(text_t* text, uint64_t i, uint64_t* x_ref, uint64_t* y_ref, uint64_t* width_ref, uint64_t* height_ref) {

--- a/aquabsd.alps/aquabsd.alps.font/functions.h
+++ b/aquabsd.alps/aquabsd.alps.font/functions.h
@@ -55,7 +55,7 @@ dynamic text_t* create_text(font_t* font, const char* str) {
 	text_colour(text, 1.0, 1.0, 1.0, 1.0);
 	text_size(text, 0);
 	text_wrap(text, 0, 0);
-	text_align(text, ALIGN_CENTRE);
+	text_align(text, ALIGN_RIGHT);
 	text_markup(text, false);
 
 	return text;
@@ -186,7 +186,12 @@ static void gen_layout(text_t* text) {
 	// update layout and get its size
 
 	pango_cairo_update_layout(text->cairo, text->layout);
-	pango_layout_get_size(text->layout, &text->x_res, &text->y_res);
+
+	PangoRectangle extents;
+	pango_layout_get_extents(text->layout, NULL, &extents);
+
+	text->x_res = extents.x + extents.width;
+	text->y_res = extents.y + extents.height;
 
 	text->x_res /= PANGO_SCALE;
 	text->y_res /= PANGO_SCALE;

--- a/aquabsd.alps/aquabsd.alps.font/functions.h
+++ b/aquabsd.alps/aquabsd.alps.font/functions.h
@@ -140,6 +140,8 @@ static void gen_layout(text_t* text) {
 		text->layout = pango_cairo_create_layout(text->cairo);
 	}
 
+	// set text and font attributes
+
 	pango_layout_set_font_description(text->layout, text->font->font_description);
 
 	#define MAX_WIDTH  0x2000
@@ -158,6 +160,21 @@ static void gen_layout(text_t* text) {
 
 	pango_layout_set_wrap(text->layout, PANGO_WRAP_WORD_CHAR); // TODO should this be settable?
 
+	pango_layout_set_justify(text->layout, text->align == ALIGN_JUSTIFY);
+
+	if (text->align == ALIGN_LEFT) {
+		pango_layout_set_alignment(text->layout, PANGO_ALIGN_LEFT);
+	}
+
+	else if (text->align == ALIGN_RIGHT) {
+		pango_layout_set_alignment(text->layout, PANGO_ALIGN_RIGHT);
+	}
+
+	else {
+		#define PANGO_ALIGN_CENTRE PANGO_ALIGN_CENTER // lol
+		pango_layout_set_alignment(text->layout, PANGO_ALIGN_CENTRE);
+	}
+
 	void (*layout_fn) (PangoLayout* layout, const char* str, int len) = pango_layout_set_text;
 
 	if (text->markup) {
@@ -165,6 +182,8 @@ static void gen_layout(text_t* text) {
 	}
 
 	layout_fn(text->layout, text->str, text->len);
+
+	// update layout and get its size
 
 	pango_cairo_update_layout(text->cairo, text->layout);
 	pango_layout_get_size(text->layout, &text->x_res, &text->y_res);

--- a/aquabsd.alps/aquabsd.alps.font/main.c
+++ b/aquabsd.alps/aquabsd.alps.font/main.c
@@ -16,32 +16,12 @@ uint64_t send(uint16_t _cmd, void* data) {
 		return (uint64_t) load_font(path);
 	}
 
-	else if (cmd == CMD_DRAW_FONT) {
-		font_t* font = (font_t*) args[0];
-		const char* string = (const char*) args[1];
-		
-		// TODO proper AXPN
-
-		float red   = *(float*) &args[2];
-		float green = *(float*) &args[3];
-		float blue  = *(float*) &args[4];
-		float alpha = *(float*) &args[5];
-
-		uint64_t wrap_width  = (uint64_t) args[6];
-		uint64_t wrap_height = (uint64_t) args[7];
-
-		uint8_t** bitmap_reference = (uint8_t**) args[8];
-		
-		uint64_t* width_reference  = (uint64_t*) args[9];
-		uint64_t* height_reference = (uint64_t*) args[10];
-
-		return (uint64_t) draw_font(font, string, red, green, blue, alpha, wrap_width, wrap_height, bitmap_reference, width_reference, height_reference);
-	}
-
 	else if (cmd == CMD_FREE_FONT) {
 		font_t* font = (font_t*) args[0];
 		return (uint64_t) free_font(font);
 	}
+
+	// TODO rest duh
 
 	return -1;
 }

--- a/aquabsd.alps/aquabsd.alps.font/main.c
+++ b/aquabsd.alps/aquabsd.alps.font/main.c
@@ -2,26 +2,116 @@
 #include <aquabsd.alps.font/functions.h>
 
 typedef enum {
-	CMD_LOAD_FONT = 0x6C66, // 'lf'
-	CMD_DRAW_FONT = 0x6466, // 'df'
-	CMD_FREE_FONT = 0x6666, // 'ff'
+	CMD_LOAD_FONT     = 0x6C66, // 'lf'
+	CMD_FREE_FONT     = 0x6666, // 'ff'
+
+	CMD_CREATE_TEXT   = 0x6374, // 'ct'
+	CMD_FREE_TEXT     = 0x6674, // 'ft'
+
+	CMD_TEXT_COLOUR   = 0x7463, // 'tc'
+	CMD_TEXT_SIZE     = 0x7473, // 'ts'
+	CMD_TEXT_WRAP     = 0x7477, // 'tw'
+	CMD_TEXT_ALIGN    = 0x7461, // 'ta'
+	CMD_TEXT_MARKUP   = 0x746D, // 'tm'
+
+	CMD_TEXT_GET_RES  = 0x6772, // 'gr'
+	CMD_TEXT_POS_TO_I = 0x7069, // 'pi'
+	CMD_TEXT_I_TO_POS = 0x6970, // 'ip'
+
+	CMD_DRAW_TEXT     = 0x6474, // 'dt'
 } cmd_t;
 
 uint64_t send(uint16_t _cmd, void* data) {
 	cmd_t cmd = _cmd;
-	uint64_t* args = (uint64_t*) data;
+	uint64_t* args = data;
 
 	if (cmd == CMD_LOAD_FONT) {
-		const char* path = (const char*) args[0];
+		const char* path = (void*) args[0];
 		return (uint64_t) load_font(path);
 	}
 
 	else if (cmd == CMD_FREE_FONT) {
-		font_t* font = (font_t*) args[0];
+		font_t* font = (void*) args[0];
 		return (uint64_t) free_font(font);
 	}
 
-	// TODO rest duh
+	else if (cmd == CMD_TEXT_COLOUR) {
+		text_t* text = (void*) args[0];
+
+		float r = *(float*) args[1];
+		float g = *(float*) args[2];
+		float b = *(float*) args[3];
+		float a = *(float*) args[4];
+
+		return text_colour(text, r, g, b, a);
+	}
+
+	else if (cmd == CMD_TEXT_SIZE) {
+		text_t* text = (void*) args[0];
+		uint64_t size = args[1];
+
+		return text_size(text, size);
+	}
+
+	else if (cmd == CMD_TEXT_WRAP) {
+		text_t* text = (void*) args[0];
+
+		uint64_t wrap_width  = args[1];
+		uint64_t wrap_height = args[2];
+
+		return text_wrap(text, wrap_width, wrap_height);
+	}
+
+	else if (cmd == CMD_TEXT_ALIGN) {
+		text_t* text = (void*) args[0];
+		align_t align = args[1];
+
+		return text_align(text, align);
+	}
+
+	else if (cmd == CMD_TEXT_MARKUP) {
+		text_t* text = (void*) args[0];
+		bool markup = args[1];
+
+		return text_markup(text, markup);
+	}
+
+	else if (cmd == CMD_TEXT_GET_RES) {
+		text_t* text = (void*) args[0];
+
+		uint64_t* x_res_ref = (void*) args[1];
+		uint64_t* y_res_ref = (void*) args[2];
+
+		return text_get_res(text, x_res_ref, y_res_ref);
+	}
+
+	else if (cmd == CMD_TEXT_POS_TO_I) {
+		text_t* text = (void*) args[0];
+
+		uint64_t x = args[1];
+		uint64_t y = args[2];
+
+		return text_pos_to_i(text, x, y);
+	}
+
+	else if (cmd == CMD_TEXT_I_TO_POS) {
+		text_t* text = (void*) args[0];
+		uint64_t i = args[1];
+
+		uint64_t* x_ref      = (void*) args[2];
+		uint64_t* y_ref      = (void*) args[3];
+		uint64_t* width_ref  = (void*) args[4];
+		uint64_t* height_ref = (void*) args[5];
+
+		return text_i_to_pos(text, i, x_ref, y_ref, width_ref, height_ref);
+	}
+
+	else if (cmd == CMD_DRAW_TEXT) {
+		text_t* text = (void*) args[0];
+		uint8_t** bmp_ref = (void*) args[1];
+
+		return draw_text(text, bmp_ref);
+	}
 
 	return -1;
 }

--- a/aquabsd.alps/aquabsd.alps.font/private.h
+++ b/aquabsd.alps/aquabsd.alps.font/private.h
@@ -8,4 +8,11 @@
 #include <unicode/utf.h>
 #include <unicode/ustring.h>
 
-#define font_t aquabsd_alps_font_t
+#define ALIGN_LEFT    AQUABSD_ALPS_FONT_ALIGN_LEFT
+#define ALIGN_RIGHT   AQUABSD_ALPS_FONT_ALIGN_RIGHT
+#define ALIGN_CENTRE  AQUABSD_ALPS_FONT_ALIGN_CENTRE
+#define ALIGN_JUSTIFY AQUABSD_ALPS_FONT_ALIGN_JUSTIFY
+
+#define font_t  aquabsd_alps_font_t
+#define align_t aquabsd_alps_font_align_t
+#define text_t  aquabsd_alps_font_text_t

--- a/aquabsd.alps/aquabsd.alps.font/public.h
+++ b/aquabsd.alps/aquabsd.alps.font/public.h
@@ -20,6 +20,16 @@ typedef enum {
 } aquabsd_alps_font_align_t;
 
 typedef struct {
+	// the 'dirty' field is set whenever layout settings change
+	// this is so that we can wait until we actually need the layout object before generating it
+	// this is for optimization purposes
+
+	bool dirty;
+
+	// pango stuff
+
+	cairo_surface_t* surface;
+	cairo_t* cairo;
 	PangoLayout* layout;
 
 	// mandatory fields
@@ -29,30 +39,35 @@ typedef struct {
 	char* str;
 	size_t len;
 
-	float red, green, blue, alpha;
-
 	// optional fields
 
+	float r, g, b, a;
 	uint64_t size; // in pixels, this is optional because, in the default case, the size will simply be that of the font
 	uint64_t wrap_width, wrap_height;
 	aquabsd_alps_font_align_t align;
 	bool markup;
+
+	// generated fields (after layout)
+
+	int x_res, y_res;
 } aquabsd_alps_font_text_t;
 
 aquabsd_alps_font_t* (*aquabsd_alps_font_load_font) (const char* path);
 int (*aquabsd_alps_font_free_font) (aquabsd_alps_font_t* font);
 
-aquabsd_alps_font_text_t* (*aquabsd_alps_font_create_text) (aquabsd_alps_font_t* font, const char* str, float red, float green, float blue, float alpha);
+aquabsd_alps_font_text_t* (*aquabsd_alps_font_create_text) (aquabsd_alps_font_t* font, const char* str);
 int (*aquabsd_alps_font_free_text) (aquabsd_alps_font_text_t* text);
 
+int (*aquabsd_alps_font_text_colour) (aquabsd_alps_font_text_t* text, float r, float g, float b, float a);
 int (*aquabsd_alps_font_text_size) (aquabsd_alps_font_text_t* text, uint64_t size);
-int (*aquabsd_alps_font_text_wrapping) (aquabsd_alps_font_text_t* text, uint64_t wrap_width, uint64_t wrap_height);
+int (*aquabsd_alps_font_text_wrap) (aquabsd_alps_font_text_t* text, uint64_t wrap_width, uint64_t wrap_height);
 int (*aquabsd_alps_font_text_align) (aquabsd_alps_font_text_t* text, aquabsd_alps_font_align_t align);
 int (*aquabsd_alps_font_text_markup) (aquabsd_alps_font_text_t* text, bool markup);
 
+int (*aquabsd_alps_font_text_get_res) (aquabsd_alps_font_text_t* text, uint64_t* x_res_ref, uint64_t* y_res_ref);
 int (*aquabsd_alps_font_text_pos_to_i) (aquabsd_alps_font_text_t* text, uint64_t x, uint64_t y);
-int (*aquabsd_alps_font_text_i_to_pos) (aquabsd_alps_font_text_t* text, uint64_t i, uint64_t x_ref, uint64_t y_ref, uint64_t width_ref, uint64_t height_ref);
+int (*aquabsd_alps_font_text_i_to_pos) (aquabsd_alps_font_text_t* text, uint64_t i, uint64_t* x_ref, uint64_t* y_ref, uint64_t* width_ref, uint64_t* height_ref);
 
-int (*aquabsd_alps_font_draw_text) (aquabsd_alps_font_text_t* text, uint8_t** bitmap_ref, uint64_t* width_ref, uint64_t* height_ref);
+int (*aquabsd_alps_font_draw_text) (aquabsd_alps_font_text_t* text, uint8_t** bmp_ref);
 
 #endif

--- a/aquabsd.alps/aquabsd.alps.font/public.h
+++ b/aquabsd.alps/aquabsd.alps.font/public.h
@@ -9,7 +9,12 @@
 #include <pango/pangocairo.h>
 
 typedef struct {
-	PangoFontDescription* font_description;
+	PangoFontDescription* font_descr;
+
+	// initial size may either be in points (non-absolute), or in device units (absolute, what aquaBSD uses)
+
+	bool init_size_abs;
+	double init_size;
 } aquabsd_alps_font_t;
 
 typedef enum {

--- a/aquabsd.alps/aquabsd.alps.font/public.h
+++ b/aquabsd.alps/aquabsd.alps.font/public.h
@@ -2,6 +2,7 @@
 #define __AQUABSD_ALPS_FONT
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // yes, it is insanely inelegant to have to use Cairo to render simple bitmaps
 
@@ -11,8 +12,47 @@ typedef struct {
 	PangoFontDescription* font_description;
 } aquabsd_alps_font_t;
 
+typedef enum {
+	AQUABSD_ALPS_FONT_ALIGN_LEFT,
+	AQUABSD_ALPS_FONT_ALIGN_RIGHT,
+	AQUABSD_ALPS_FONT_ALIGN_CENTRE,
+	AQUABSD_ALPS_FONT_ALIGN_JUSTIFY,
+} aquabsd_alps_font_align_t;
+
+typedef struct {
+	PangoLayout* layout;
+
+	// mandatory fields
+
+	aquabsd_alps_font_t* font;
+
+	char* str;
+	size_t len;
+
+	float red, green, blue, alpha;
+
+	// optional fields
+
+	uint64_t size; // in pixels, this is optional because, in the default case, the size will simply be that of the font
+	uint64_t wrap_width, wrap_height;
+	aquabsd_alps_font_align_t align;
+	bool markup;
+} aquabsd_alps_font_text_t;
+
 aquabsd_alps_font_t* (*aquabsd_alps_font_load_font) (const char* path);
 int (*aquabsd_alps_font_free_font) (aquabsd_alps_font_t* font);
-int (*aquabsd_alps_font_draw_font) (aquabsd_alps_font_t* font, const char* string, float red, float green, float blue, float alpha, uint64_t wrap_width, uint64_t wrap_height, uint8_t** bitmap_reference, uint64_t* width_reference, uint64_t* height_reference);
+
+aquabsd_alps_font_text_t* (*aquabsd_alps_font_create_text) (aquabsd_alps_font_t* font, const char* str, float red, float green, float blue, float alpha);
+int (*aquabsd_alps_font_free_text) (aquabsd_alps_font_text_t* text);
+
+int (*aquabsd_alps_font_text_size) (aquabsd_alps_font_text_t* text, uint64_t size);
+int (*aquabsd_alps_font_text_wrapping) (aquabsd_alps_font_text_t* text, uint64_t wrap_width, uint64_t wrap_height);
+int (*aquabsd_alps_font_text_align) (aquabsd_alps_font_text_t* text, aquabsd_alps_font_align_t align);
+int (*aquabsd_alps_font_text_markup) (aquabsd_alps_font_text_t* text, bool markup);
+
+int (*aquabsd_alps_font_text_pos_to_i) (aquabsd_alps_font_text_t* text, uint64_t x, uint64_t y);
+int (*aquabsd_alps_font_text_i_to_pos) (aquabsd_alps_font_text_t* text, uint64_t i, uint64_t x_ref, uint64_t y_ref, uint64_t width_ref, uint64_t height_ref);
+
+int (*aquabsd_alps_font_draw_text) (aquabsd_alps_font_text_t* text, uint8_t** bitmap_ref, uint64_t* width_ref, uint64_t* height_ref);
 
 #endif


### PR DESCRIPTION
This revamp aims to:

- [x] Declutter the text drawing command's argument list.
- [x] Introduce a separate text object, which contains information about the layout and may be queried without rendering the text bitmap first.
- [x] Give more control over text attributes (size, alignment, &c) through new commands operating on text objects.
- [x] Provide more information about how text is laid out (cursor coordinate to character index conversion and vice-versa).

The new API has already been laid out; now it's just a matter of implementing it.