### PR TITLE
aquabsd.alps: Offload framebuffer rendering to windows from the `vga` device

### DIFF
--- a/aquabsd.alps/aquabsd.alps.win/build.sh
+++ b/aquabsd.alps/aquabsd.alps.win/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-cc "$@" -shared -fPIC -lxcb -lxcb-icccm -lxcb-ewmh -lX11 -lX11-xcb
+cc "$@" -shared -fPIC -lxcb -lxcb-ewmh -lxcb-icccm -lxcb-image -lX11 -lX11-xcb

--- a/aquabsd.alps/aquabsd.alps.win/private.h
+++ b/aquabsd.alps/aquabsd.alps.win/private.h
@@ -2,6 +2,12 @@
 
 #include <aquabsd.alps.win/public.h>
 
+#if __ORDER_LITTLE_ENDIAN == __BYTE_ORDER__
+	#define NATIVE_XCB_IMAGE_ORDER XCB_IMAGE_ORDER_LSB_FIRST
+#else
+	#define NATIVE_XCB_IMAGE_ORDER XCB_IMAGE_ORDER_MSB_FIRST
+#endif
+
 uint64_t (*kos_query_device) (uint64_t, uint64_t name);
 void* (*kos_load_device_function) (uint64_t device, const char* name);
 uint64_t (*kos_callback) (uint64_t callback, int argument_count, ...);


### PR DESCRIPTION
Before the `aquabsd.alps.win` device existed as it does now, I needed a way to test the `aquabsd.alps.vga` device as an X11 client, so I wrote a quick backend (the X11 backend) which just created a window and drew to it using the MIT-SHM extension. Now that `aquabsd.alps.win` exists, this means there's a lot of redundant code between the two; this PR aims to merge the X11 backend of `aquabsd.alps.vga` into `aquabsd.alps.win`.

The advantages of this are:

- Greater flexibility for programs/other devices using `aquabsd.alps.win`, as they may now benefit from proper framebuffer support (e.g. for platforms which don't have the graphical acceleration capabilities to create EGL contexts in windows using `aquabsd.alps.ogl`).
- Greater code reuse.
- Simplified library interaction. E.g., all UI backends use the `aquabsd.alps.win` API for the OGL & FB backends rather than two different ones.

What needs to be done:

- [ ] Commands for creating and interacting with framebuffers in windows.
- [ ] Restructuring of the `aquabsd.alps.vga` device. (I'm not yet sure how I want this to work; should it be completely removed and the `aquabsd_vga` backend somehow merged into `aquabsd.alps.win`, should it be a replacement device for `aquabsd.alps.win`, ...?)
- [ ] Simplification of the UI library to not worry about `aquabsd.alps.vga` anymore (depends how I decide the above point is gonna work).
- [ ] Rewriting of programs which currently use `aquabsd.alps.vga`.